### PR TITLE
Improve dev setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,13 +14,15 @@ RUN apt-get update && apt-get install -y \
     git \
     cmake \
     ninja-build \
-    wget 
+    wget \
+    nano
 
 # Install latest clang-format
 RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" >> /etc/apt/sources.list \
     && wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
     && apt-get update && apt-get install -y clang-format-19 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/clang-format-19 /usr/local/bin/clang-format
 ENV CLANG_FORMAT="/usr/bin/clang-format-19"
 
 # Install arm-none-eabi by xpack

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,10 @@
         }
     },
     "postStartCommand": {
+        // Init submodules
+        "submodules": "git submodule update --init --recursive",
+        // Place .clang-format file in parent of the project folder so its detected by formatonsave
+        "clang-format": "cp ${containerWorkspaceFolder}/src/third_party/rocketlib/.clang-format ${containerWorkspaceFolder}/../.clang-format",
         // Enable git tab-autocompletion in terminal
         "autocomplete": "echo \"source /usr/share/bash-completion/completions/git\" >> ~/.bashrc",
         // Use vscode as default editor cuz nano/vim arent installed and ppl can install those by preference

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ STM32CubeIDE is preferred for flashing/debugging on hardware. NOTE: STM32CubeIDE
 #### *ALTERNATIVE 4. Run/debug via Vscode STM32 extension*
 *Instead of using STM32CubeIDE, run/debug in vscode is possible using the STM32 vscode extension ([setup info here](https://community.st.com/t5/stm32-mcus/how-to-use-vs-code-with-stm32-microcontrollers/ta-p/742589) ). This was omitted from the devcontainer because 1. CubeIDE debugging features are stronger, and 2. usb passthrough into devcontainers is non-trivial.*
 
-## Testing
+## Unit Testing
 The project uses GoogleTest and Fake Function Framework (fff) for unit testing. All testing-related files are in `tests/`.
 - Tests are built from `tests/CMakeLists.txt` which is separate from the project's main build config. Building and running tests is done from `scripts/run.sh` described above.
 - Test source code should be written in `tests/unit/`.
@@ -86,9 +86,15 @@ Example:
 Use `./scripts/run.sh` as described above.
 
 
+## Debugging
+- Use STM32CubeIDE debugging as directed above
+- The ST-link programmer has a serial output so you can listen to uart4 from a laptop COM port. The printf library (NOT THE STDLIB PRINTF) is configured to print strings to that COM port. Use `printf_("string to print..")` - note the `_` character.
+  - This should rarely be used. Please instead learn how to use the debugger (breakpoints, step, etc) for efficient and pleasant debugging.
+
 ## Code Standards
 - This project follows the [team-wide embedded coding standard](https://docs.waterloorocketry.com/general/standards/embedded-coding-standard.html).
-- Use clang-format for automatic code formatting. The script must be run from the project root directory:
+- The devcontainer sets up vscode format-on-save to automatically use the team's clang-format.
+  - In case you want to manually run it, the script can be run from the project root directory:
   ```bash
   ./scripts/format.sh
   ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The devcontainer contains the necessary environment setup for editing, unit test
     - The first time opening the project will take several minutes to build the devcontainer. Subsequent times will be instant.
 
 #### 3. Build and test project in devcontainer
-Use `/scripts/run.sh` from a terminal inside the devcontainer to build the project and/or run unit tests.
+Use `./scripts/run.sh` from a terminal inside the devcontainer to build the project and/or run unit tests.
 Some example script usages:
 
 Show how to use the script:


### PR DESCRIPTION
~~added a git pre-commit hook that automatically runs the format.sh script everytime you do `git commit`. theoretically this means you never have to run the format.sh script manually, and everyone's commits will pass the format check always!~~
fixed vscode formatonsave to use our clang-format

tested on 2 laptops. requesting more ppl test and try to break this. It will require rebuilding the vscode devcontainer after checking out to this branch (google it)