### PR TITLE
Specify platform for Docker image compatibility

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Use Ubuntu as the base image
-FROM ubuntu:22.04
+FROM --platform=linux/amd64 ubuntu:22.04
 
 # Set non-interactive mode for apt-get
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,19 +18,20 @@
         }
     },
     "postStartCommand": {
-        // Init submodules
-        "submodules": "git submodule update --init --recursive",
         // Place .clang-format file in parent of the project folder so its detected by formatonsave
         "clang-format": "cp ${containerWorkspaceFolder}/src/third_party/rocketlib/.clang-format ${containerWorkspaceFolder}/../.clang-format",
         // Enable git tab-autocompletion in terminal
         "autocomplete": "echo \"source /usr/share/bash-completion/completions/git\" >> ~/.bashrc",
         // Use vscode as default editor cuz nano/vim arent installed and ppl can install those by preference
         "setEditor": "git config --global core.editor 'code --wait'",
-        // Avoid git unsafe repos warning caused by devcontainer ownership perms clash
+        // Avoid git unsafe repos warning caused by devcontainer ownership perms clash TODO: this shouldnt be necessary ???
         "safeRepo1": "git config --global --add safe.directory ${containerWorkspaceFolder}",
         "safeRepo2": "git config --global --add safe.directory ${containerWorkspaceFolder}/src/third_party/canlib",
         "safeRepo3": "git config --global --add safe.directory ${containerWorkspaceFolder}/src/third_party/rocketlib",
-        "safeRepo4": "git config --global --add safe.directory ${containerWorkspaceFolder}/tests/mocks/fff"
+        "safeRepo4": "git config --global --add safe.directory ${containerWorkspaceFolder}/tests/mocks/fff",
+        "safeRepo5": "git config --global --add safe.directory ${containerWorkspaceFolder}/tests/external/googletest",
+        // Init submodules after theyre all safe
+        "submodules": "git submodule update --init --recursive"
     },
     // Mount proc folder into the container
     "mounts": [


### PR DESCRIPTION
Ensure the Docker image is compatible with the arm-none-eabi gcc toolchain by explicitly specifying the platform of the image (if left unspecified, docker downloads the image based on the user's architecture system, big issue for mac users if left unspecified because of build failures). potential investigatory options are as follows regarding this: 

we can either a) hate on mac users on arm64 by forcing them to run x86 images and the binaries through rosetta 2 (tbh not even that slow) or b) change our dockerfile to download a diff toolchain architecture based on the host architecture kind of a hassle but not too annoying of a change. this pr implements option a).