### PR TITLE
assorted updates

### DIFF
--- a/FATFS/Target/sd_diskio.c
+++ b/FATFS/Target/sd_diskio.c
@@ -22,6 +22,8 @@
 
 /* USER CODE BEGIN firstSection */
 /* can be used to modify / undefine following code or add new definitions */
+#include "FreeRTOS.h"
+#include "task.h"
 /* USER CODE END firstSection*/
 
 /* Includes ------------------------------------------------------------------*/
@@ -219,6 +221,7 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
       timeout = HAL_GetTick();
       while((ReadStatus == 0) && ((HAL_GetTick() - timeout) < SD_TIMEOUT))
       {
+        vTaskDelay(pdMS_TO_TICKS(3));
       }
       /* in case of a timeout return error */
       if (ReadStatus == 0)
@@ -244,6 +247,10 @@ DRESULT SD_read(BYTE lun, BYTE *buff, DWORD sector, UINT count)
             SCB_InvalidateDCache_by_Addr((uint32_t*)alignedAddr, count*BLOCKSIZE + ((uint32_t)buff - alignedAddr));
 #endif
             break;
+          }
+          else
+          {
+            vTaskDelay(pdMS_TO_TICKS(3));
           }
         }
       }
@@ -350,6 +357,7 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
       timeout = HAL_GetTick();
       while((WriteStatus == 0) && ((HAL_GetTick() - timeout) < SD_TIMEOUT))
       {
+        vTaskDelay(pdMS_TO_TICKS(3));
       }
       /* in case of a timeout return error */
       if (WriteStatus == 0)
@@ -367,6 +375,10 @@ DRESULT SD_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
           {
             res = RES_OK;
             break;
+          }
+          else
+          {
+            vTaskDelay(pdMS_TO_TICKS(3));
           }
         }
       }

--- a/scripts/logparse.py
+++ b/scripts/logparse.py
@@ -35,17 +35,31 @@ FORMATS = {
     M(0x01): Spec("test", "<f", ["test_val"]),  
     M(0x02): Spec("canard_cmd", "f", ["cmd_angle"]),
     M(0x03): Spec("controller_input", "<Lfffff", ["timestamp", "roll_angle", "roll_rate", "canard_angle", "canard_coeff", "pressure_dynamic"]),
-    M(0x04): Spec("imu_reading", "<LfffLfffLfff?b", ["polulu_timestamp","polulu_accel_x","polulu_accel_y","polulu_accel_z","polulu_gyro_x","polulu_gyro_y","polulu_gyro_z","polulu_mag_x","polulu_mag_y","polulu_mag_z","polulu_barometer","polulu_is_dead","movella_timestamp","movella_accel_x","movella_accel_y","movella_accel_z","movella_gyro_x","movella_gyro_y","movella_gyro_z","movella_mag_x","movella_mag_y","movella_mag_z","movella_barometer","movella_is_dead"]),
+    M(0x04): Spec(
+    "estimator_all_imus_input",
+    "<Ldddddddddf?Ldddddddddf?",
+    [
+        "polulu_time",
+        "polulu_acc_x", "polulu_acc_y", "polulu_acc_z",
+        "polulu_gyr_x", "polulu_gyr_y", "polulu_gyr_z",
+        "polulu_mag_x", "polulu_mag_y", "polulu_mag_z",
+        "polulu_bar",
+        "polulu_is_dead",
+        "movella_time",
+        "movella_acc_x", "movella_acc_y", "movella_acc_z",
+        "movella_gyr_x", "movella_gyr_y", "movella_gyr_z",
+        "movella_mag_x", "movella_mag_y", "movella_mag_z",
+        "movella_baro",
+        "movella_is_dead"
+    ]),
     M(0x05): Spec("x_state", "<ddddddddddddd",
     [
         "attitude_w", "attitude_x", "attitude_y", "attitude_z",
         "rates_x", "rates_y", "rates_z",
         "velocity_x", "velocity_y", "velocity_z",
         "altitude", "CL", "delta"
-    ],
+    ]),
     M(0x06): Spec("encoder", "<H", ["encoder_value"]),
-),
-
 }
 
 def parse_argv(argv):

--- a/scripts/logparse.py
+++ b/scripts/logparse.py
@@ -35,9 +35,7 @@ FORMATS = {
     M(0x01): Spec("test", "<f", ["test_val"]),  
     M(0x02): Spec("canard_cmd", "f", ["cmd_angle"]),
     M(0x03): Spec("controller_input", "<Lfffff", ["timestamp", "roll_angle", "roll_rate", "canard_angle", "canard_coeff", "pressure_dynamic"]),
-    M(0x04): Spec(
-    "estimator_all_imus_input",
-    "<Ldddddddddf?Ldddddddddf?",
+    M(0x04): Spec("pololu", "<Ldddddddddf?",
     [
         "polulu_time",
         "polulu_acc_x", "polulu_acc_y", "polulu_acc_z",
@@ -45,12 +43,6 @@ FORMATS = {
         "polulu_mag_x", "polulu_mag_y", "polulu_mag_z",
         "polulu_bar",
         "polulu_is_dead",
-        "movella_time",
-        "movella_acc_x", "movella_acc_y", "movella_acc_z",
-        "movella_gyr_x", "movella_gyr_y", "movella_gyr_z",
-        "movella_mag_x", "movella_mag_y", "movella_mag_z",
-        "movella_baro",
-        "movella_is_dead"
     ]),
     M(0x05): Spec("x_state", "<ddddddddddddd",
     [
@@ -60,6 +52,15 @@ FORMATS = {
         "altitude", "CL", "delta"
     ]),
     M(0x06): Spec("encoder", "<H", ["encoder_value"]),
+    M(0x07): Spec("movella", "<Ldddddddddf?",
+    [
+        "polulu_time",
+        "polulu_acc_x", "polulu_acc_y", "polulu_acc_z",
+        "polulu_gyr_x", "polulu_gyr_y", "polulu_gyr_z",
+        "polulu_mag_x", "polulu_mag_y", "polulu_mag_z",
+        "polulu_bar",
+        "polulu_is_dead",
+    ]),
 }
 
 def parse_argv(argv):

--- a/scripts/logparse.py
+++ b/scripts/logparse.py
@@ -33,9 +33,19 @@ FORMATS = {
     # Insert new types above this line in the format:
     # M(unique_small_integer): Spec(name, format, [field, ...]),
     M(0x01): Spec("test", "<f", ["test_val"]),  
-    M(0x02): Spec("controller", "f", ["cmd_angle"]),
-    M(0x03): Spec("controller_output", "<fL", ["commanded_angle", "timestamp"]),
+    M(0x02): Spec("canard_cmd", "f", ["cmd_angle"]),
+    M(0x03): Spec("controller_input", "<Lfffff", ["timestamp", "roll_angle", "roll_rate", "canard_angle", "canard_coeff", "pressure_dynamic"]),
     M(0x04): Spec("imu_reading", "<LfffLfffLfff?b", ["polulu_timestamp","polulu_accel_x","polulu_accel_y","polulu_accel_z","polulu_gyro_x","polulu_gyro_y","polulu_gyro_z","polulu_mag_x","polulu_mag_y","polulu_mag_z","polulu_barometer","polulu_is_dead","movella_timestamp","movella_accel_x","movella_accel_y","movella_accel_z","movella_gyro_x","movella_gyro_y","movella_gyro_z","movella_mag_x","movella_mag_y","movella_mag_z","movella_barometer","movella_is_dead"]),
+    M(0x05): Spec("x_state", "<ddddddddddddd",
+    [
+        "attitude_w", "attitude_x", "attitude_y", "attitude_z",
+        "rates_x", "rates_y", "rates_z",
+        "velocity_x", "velocity_y", "velocity_z",
+        "altitude", "CL", "delta"
+    ],
+    M(0x06): Spec("encoder", "<H", ["encoder_value"]),
+),
+
 }
 
 def parse_argv(argv):

--- a/src/application/can_handler/can_handler.c
+++ b/src/application/can_handler/can_handler.c
@@ -104,7 +104,7 @@ w_status_t can_handler_register_callback(can_msg_type_t msg_type, can_callback_t
 
 w_status_t can_handler_transmit(const can_msg_t *message) {
     if (pdPASS != xQueueSend(bus_queue_tx, message, 0)) {
-        log_text(1, "CANHandler", "ERROR: Failed to queue message for TX. Queue full?");
+        log_text(1, "can_handler_transmit", "tx queue full");
         can_handler_status.dropped_tx_counter++;
         return W_FAILURE;
     }
@@ -155,7 +155,7 @@ void can_handler_task_tx(void *argument) {
                 // expect we send at least 1 message every 1.5sec
                 TickType_t now = xTaskGetTickCount();
                 if ((now - last_tx_warn_tick) >= pdMS_TO_TICKS(1500)) {
-                    log_text(1, "CANHandlerTX", "WARN: Timed out waiting for TX message.");
+                    log_text(1, "CANHandlerTX", "no tx msg in queue");
                     last_tx_warn_tick = now;
                 }
             }

--- a/src/application/can_handler/can_handler.h
+++ b/src/application/can_handler/can_handler.h
@@ -6,6 +6,11 @@
 #include "stm32h7xx_hal.h"
 #include <stdint.h>
 
+typedef struct {
+    uint32_t dropped_rx_counter; // Number of dropped RX msg from rx isr
+    uint32_t dropped_tx_counter; // Number of dropped TX messages from can_send()
+} can_handler_status_t;
+
 // Signature for rx callback functions
 typedef w_status_t (*can_callback_t)(const can_msg_t *);
 

--- a/src/application/controller/controller.c
+++ b/src/application/controller/controller.c
@@ -138,7 +138,7 @@ void controller_task(void *argument) {
 
                 data_container.controller.cmd_angle = controller_output.commanded_angle;
                 if (W_SUCCESS !=
-                    log_data(CONTROLLER_CYCLE_TIMEOUT_MS, LOG_TYPE_CONTROLLER, &data_container)) {
+                    log_data(CONTROLLER_CYCLE_TIMEOUT_MS, LOG_TYPE_CANARD_CMD, &data_container)) {
                     log_text(ERROR_TIMEOUT_MS, "controller", "timeout for logging commanded angle");
                 }
 
@@ -202,7 +202,7 @@ void controller_task(void *argument) {
 
                 data_container.controller.cmd_angle = controller_output.commanded_angle;
                 if (W_SUCCESS !=
-                    log_data(CONTROLLER_CYCLE_TIMEOUT_MS, LOG_TYPE_CONTROLLER, &data_container)) {
+                    log_data(CONTROLLER_CYCLE_TIMEOUT_MS, LOG_TYPE_CANARD_CMD, &data_container)) {
                     log_text(ERROR_TIMEOUT_MS, "controller", "timeout for logging commanded angle");
                 }
 

--- a/src/application/controller/controller.c
+++ b/src/application/controller/controller.c
@@ -101,8 +101,9 @@ void controller_task(void *argument) {
     (void)argument;
     float current_timestamp_ms = 0.0f;
     log_data_container_t data_container = {0};
-    TickType_t last_wake_time;
-    last_wake_time = xTaskGetTickCount();
+    // see TODO below...
+    // TickType_t last_wake_time;
+    // last_wake_time = xTaskGetTickCount();
 
     while (true) {
         // no phase change track
@@ -142,9 +143,13 @@ void controller_task(void *argument) {
                     log_text(ERROR_TIMEOUT_MS, "controller", "timeout for logging commanded angle");
                 }
 
-                vTaskDelayUntil(
-                    &last_wake_time, pdMS_TO_TICKS(RECOVERY_TIMEOUT_MS)
-                ); // 1s per iteration
+                // delay 1s per iteration. not as precise as taskdelayuntil but doesnt matter here.
+                // AVOID vtaskdelayuntil: it breaks cuz we dont use it in ACT_ALLOWED phase, so
+                // last_wake_time doesnt get updated consistently and causes this to break as it
+                // tries to catch up in time. TDOO: update freertos versions to where delayuntil has
+                // a return value...
+                vTaskDelay(pdMS_TO_TICKS(RECOVERY_TIMEOUT_MS));
+                // vTaskDelayUntil(&last_wake_time, pdMS_TO_TICKS(RECOVERY_TIMEOUT_MS));
                 break;
             case STATE_ACT_ALLOWED:
                 // wait for new state data (5ms timeout)

--- a/src/application/estimator/estimator.c
+++ b/src/application/estimator/estimator.c
@@ -172,10 +172,14 @@ w_status_t estimator_run_loop(uint32_t loop_count) {
                 return W_FAILURE;
             }
 
-            // ------- do data logging at 200hz (every loop) -------
+            // ------- do sdcard data logging at 200hz (every loop) -------
             log_data_container_t log_data_payload = {0};
-            log_data_payload.estimator_output = output_to_controller; // Copy struct
-            log_data(1, LOG_TYPE_ESTIMATOR_OUTPUT, &log_data_payload);
+            // log data sent to controller
+            log_data_payload.controller_input = output_to_controller; // Copy struct
+            log_data(1, LOG_TYPE_CONTROLLER_INPUT, &log_data_payload);
+            // log current state est state
+            log_data_payload.estimator_state = dummy_state; // Copy struct
+            log_data(1, LOG_TYPE_ESTIMATOR_STATE, &log_data_payload);
 
             // do CAN logging as backup less frequently to avoid flooding can bus
             if (loop_count % ESTIMATOR_CAN_TX_RATE == 0) {

--- a/src/application/estimator/estimator.c
+++ b/src/application/estimator/estimator.c
@@ -20,8 +20,8 @@ extern TaskHandle_t estimator_task_handle;
 
 // ---------- private variables ----------
 static const uint32_t ESTIMATOR_TASK_PERIOD_MS = 5;
-// rate limit CAN tx: only send data every 5 times estimator runs
-static const uint32_t ESTIMATOR_CAN_TX_RATE = 5;
+// rate limit CAN tx: only send data every 50 times estimator runs (4hz)
+static const uint32_t ESTIMATOR_CAN_TX_RATE = 500;
 
 // latest imu readings from imu handler
 static QueueHandle_t imu_data_queue = NULL;
@@ -37,18 +37,19 @@ static QueueHandle_t controller_cmd_queue = NULL;
  */
 static w_status_t can_encoder_msg_callback(const can_msg_t *msg) {
     can_analog_sensor_id_t sensor_id;
-    uint16_t data;
+    uint16_t raw_data;
 
-    if (get_analog_data(msg, &sensor_id, &data) == false) {
+    if (get_analog_data(msg, &sensor_id, &raw_data) == false) {
         log_text(1, "Estimator", "WARN: Failed to parse analog sensor CAN msg.");
         return W_FAILURE;
     }
 
-    int16_t shifted_data = (int16_t)data - 32768; // shift back to signed
+    int16_t shifted_data = (int16_t)raw_data - 32768; // shift back to signed
 
     if (SENSOR_CANARD_ENCODER_1 == sensor_id) {
         xQueueOverwrite(encoder_data_queue, &shifted_data);
-        log_text(1, "Estimator", "encoder data: %d", data);
+        // log raw CAN data; is just a uint16_t
+        log_data(1, LOG_TYPE_ENCODER, (log_data_container_t *)&raw_data);
     }
     return W_SUCCESS;
 }
@@ -138,13 +139,14 @@ w_status_t estimator_run_loop(uint32_t loop_count) {
 
             // get the latest encoder reading. should always be populated, hence 0 wait
             if (xQueuePeek(encoder_data_queue, &latest_encoder_data, 0) != pdTRUE) {
-                log_text(3, "State estimation", "failed to receive encoder data!");
-                return W_FAILURE;
+                // RIP ENCODER FOR TEST FLIGHT
+                log_text(3, "Estimator", "failed to receive encoder data");
+                // return W_FAILURE;
             }
 
             // get the latest controller cmd
             if (controller_get_latest_output(&latest_controller_cmd) != W_SUCCESS) {
-                log_text(10, "Estimator", "ERROR: Failed to get latest controller output.");
+                log_text(10, "Estimator", "failed to get latest controller output");
                 return W_FAILURE;
             }
 
@@ -168,7 +170,7 @@ w_status_t estimator_run_loop(uint32_t loop_count) {
             // END DUMMY STATE
 
             if (controller_update_inputs(&output_to_controller) != W_SUCCESS) {
-                log_text(10, "Estimator", "ERROR: Failed to update controller inputs.");
+                log_text(10, "Estimator", "failed to update controller inputs.");
                 return W_FAILURE;
             }
 
@@ -193,7 +195,7 @@ w_status_t estimator_run_loop(uint32_t loop_count) {
             }
             break;
         default:
-            log_text(10, "Estimator", "ERROR: Invalid flight phase: %d", curr_flight_phase);
+            log_text(10, "Estimator", "invalid flight phase: %d", curr_flight_phase);
             return W_FAILURE;
             break;
     }

--- a/src/application/estimator/estimator.c
+++ b/src/application/estimator/estimator.c
@@ -21,7 +21,7 @@ extern TaskHandle_t estimator_task_handle;
 // ---------- private variables ----------
 static const uint32_t ESTIMATOR_TASK_PERIOD_MS = 5;
 // rate limit CAN tx: only send data every 50 times estimator runs (4hz)
-static const uint32_t ESTIMATOR_CAN_TX_RATE = 500;
+static const uint32_t ESTIMATOR_CAN_TX_RATE = 50;
 
 // latest imu readings from imu handler
 static QueueHandle_t imu_data_queue = NULL;

--- a/src/application/estimator/estimator.h
+++ b/src/application/estimator/estimator.h
@@ -11,10 +11,10 @@
 // measurement data from 1 arbitrary imu
 typedef struct {
     uint32_t timestamp_imu;
-    vector3d_t accelerometer;
-    vector3d_t gyroscope;
-    vector3d_t magnetometer;
-    float barometer;
+    vector3d_t accelerometer; // gravities
+    vector3d_t gyroscope; // rad/sec
+    vector3d_t magnetometer; // mgauss (pololu) or arbitrary units (movella)
+    float barometer; // Pa
     bool is_dead;
 } estimator_imu_measurement_t;
 

--- a/src/application/flight_phase/flight_phase.c
+++ b/src/application/flight_phase/flight_phase.c
@@ -9,7 +9,7 @@
 
 // TODO: these are made up values, up to FIDO what these actually are
 // See the flowchart in the design doc for more context on these
-#define ACT_DELAY_MS 9000 // Q - the minimum time after launch before allowing canards to actuate
+#define ACT_DELAY_MS 1 // Q - the minimum time after launch before allowing canards to actuate
 #define FLIGHT_TIMEOUT_MS 50000 // K - the approximate time between launch and apogee
 
 #define TASK_TIMEOUT_MS 1000

--- a/src/application/imu_handler/imu_handler.c
+++ b/src/application/imu_handler/imu_handler.c
@@ -61,6 +61,11 @@ static w_status_t read_pololu_imu(estimator_imu_measurement_t *imu_data) {
     status |= altimu_get_baro_data(&baro_data);
 
     if (W_SUCCESS == status) {
+        // convert gyro to rad/sec
+        imu_data->gyroscope.x = imu_data->gyroscope.x * M_PI / 180.0f;
+        imu_data->gyroscope.y = imu_data->gyroscope.y * M_PI / 180.0f;
+        imu_data->gyroscope.z = imu_data->gyroscope.z * M_PI / 180.0f;
+
         // Apply orientation correction
         imu_data->accelerometer =
             math_vector3d_rotate(&g_polulu_upd_mat, &(imu_data->accelerometer));

--- a/src/application/imu_handler/imu_handler.c
+++ b/src/application/imu_handler/imu_handler.c
@@ -162,10 +162,11 @@ w_status_t imu_handler_run(void) {
         log_text(1, "IMUHandler", "WARN: Movella IMU read failed.");
     }
 
-    // Log IMU data
-    log_data_container_t log_data_payload = {0};
-    log_data_payload.imu_reading = imu_data; // Copy struct
-    log_data(1, LOG_TYPE_IMU_READING, &log_data_payload);
+    // Log one imu data at a time
+    log_data_container_t log_data_container = {.imu_reading = imu_data.movella};
+    log_data(1, LOG_TYPE_MOVELLA_READING, &log_data_container);
+    log_data_container.imu_reading = imu_data.polulu;
+    log_data(1, LOG_TYPE_POLOLU_READING, &log_data_container);
 
     // Send data to estimator with status flags
     w_status_t estimator_status = estimator_update_imu_data(&imu_data);

--- a/src/application/init/init.c
+++ b/src/application/init/init.c
@@ -111,7 +111,7 @@ w_status_t system_init(void) {
     status |= init_with_retry(movella_init);
     status |= init_with_retry(flight_phase_init);
     status |= init_with_retry(imu_handler_init);
-    status |= init_with_retry_param((w_status_t (*)(void *))can_handler_init, &hfdcan1);
+    status |= init_with_retry_param((w_status_t(*)(void *))can_handler_init, &hfdcan1);
     status |= init_with_retry(controller_init);
 
     if (status != W_SUCCESS) {

--- a/src/application/init/init.c
+++ b/src/application/init/init.c
@@ -111,7 +111,7 @@ w_status_t system_init(void) {
     status |= init_with_retry(movella_init);
     status |= init_with_retry(flight_phase_init);
     status |= init_with_retry(imu_handler_init);
-    status |= init_with_retry_param((w_status_t(*)(void *))can_handler_init, &hfdcan1);
+    status |= init_with_retry_param((w_status_t (*)(void *))can_handler_init, &hfdcan1);
     status |= init_with_retry(controller_init);
 
     if (status != W_SUCCESS) {

--- a/src/application/logger/log.h
+++ b/src/application/logger/log.h
@@ -66,9 +66,10 @@ typedef enum {
     LOG_TYPE_TEST = M(0x01),
     LOG_TYPE_CANARD_CMD = M(0x02),
     LOG_TYPE_CONTROLLER_INPUT = M(0x03),
-    LOG_TYPE_IMU_READING = M(0x04),
+    LOG_TYPE_MOVELLA_READING = M(0x04),
     LOG_TYPE_ESTIMATOR_STATE = M(0x05),
     LOG_TYPE_ENCODER = M(0x06),
+    LOG_TYPE_POLOLU_READING = M(0x07),
     // Insert new types above this line in the format:
     // LOG_TYPE_XXX = M(unique_small_integer),
 } log_data_type_t;
@@ -97,8 +98,9 @@ typedef union __attribute__((packed)) {
     } controller;
     // LOG_TYPE_CONTROLLER_INPUT:
     controller_input_t __attribute__((packed)) controller_input; // Using typedef name
-    // LOG_TYPE_IMU_READING:
-    estimator_all_imus_input_t __attribute__((packed)) imu_reading; // Using typedef name
+    // LOG_TYPE_MOVELLA_READING or LOG_TYPE_POLOLU_READING:
+    // note: dont use the all_imus_input_t struct here because packing isn't recursive
+    estimator_imu_measurement_t __attribute__((packed)) imu_reading;
     // LOG_TYPE_ESTIMATOR_STATE:
     x_state_t __attribute__((packed)) estimator_state; // Using typedef name
     // LOG_TYPE_ENCODER:

--- a/src/application/logger/log.h
+++ b/src/application/logger/log.h
@@ -63,13 +63,14 @@
  */
 typedef enum {
     LOG_TYPE_HEADER = 0x44414548, // "HEAD" encoded as a little-endian 32-bit int
-    // Insert new types above this line in the format:
-    LOG_TYPE_ESTIMATOR_OUTPUT = M(0x02),
-    LOG_TYPE_CONTROLLER_OUTPUT = M(0x03),
-    LOG_TYPE_IMU_READING = M(0x04),
     LOG_TYPE_TEST = M(0x01),
+    LOG_TYPE_CANARD_CMD = M(0x02),
+    LOG_TYPE_CONTROLLER_INPUT = M(0x03),
+    LOG_TYPE_IMU_READING = M(0x04),
+    LOG_TYPE_ESTIMATOR_STATE = M(0x05),
+    LOG_TYPE_ENCODER = M(0x06),
+    // Insert new types above this line in the format:
     // LOG_TYPE_XXX = M(unique_small_integer),
-    LOG_TYPE_CONTROLLER = M(0x02),
 } log_data_type_t;
 
 #undef M
@@ -78,12 +79,10 @@ typedef enum {
  * The container for data to be included in messages from log_data().
  * Make sure to update format descriptions in scripts/logparse.py too!
  */
-// Forward declare structs used in the union
-// struct controller_input_s; // Removed forward declarations
-// struct controller_output_s;
-// struct estimator_all_imus_input_s;
-
+// Add structs for each type defined in log_data_type_t
+// Please include `__attribute__((packed))` in struct declarations
 typedef union __attribute__((packed)) {
+    // LOG_TYPE_HEADER:
     struct __attribute__((packed)) {
         uint32_t version;
         uint32_t index;
@@ -92,15 +91,18 @@ typedef union __attribute__((packed)) {
     struct __attribute__((packed)) {
         float test_val;
     } test;
-    // LOG_TYPE_CONTROLLER:
+    // LOG_TYPE_CANARD_CMD:
     struct __attribute__((packed)) {
         float cmd_angle;
     } controller;
-    // Add structs for each type defined in log_data_type_t
-    // Please include `__attribute__((packed))` in struct declarations
-    controller_input_t __attribute__((packed)) estimator_output; // Using typedef name
-    controller_output_t __attribute__((packed)) controller_output; // Using typedef name
+    // LOG_TYPE_CONTROLLER_INPUT:
+    controller_input_t __attribute__((packed)) controller_input; // Using typedef name
+    // LOG_TYPE_IMU_READING:
     estimator_all_imus_input_t __attribute__((packed)) imu_reading; // Using typedef name
+    // LOG_TYPE_ESTIMATOR_STATE:
+    x_state_t __attribute__((packed)) estimator_state; // Using typedef name
+    // LOG_TYPE_ENCODER:
+    uint16_t encoder;
 } log_data_container_t;
 
 /**

--- a/src/drivers/movella/movella.h
+++ b/src/drivers/movella/movella.h
@@ -10,7 +10,7 @@ typedef struct {
     vector3d_t acc; // (x, y, z) m/s^2
     vector3d_t gyr; // (x, y, z) rad/s
     vector3d_t euler; // (x, y, z) deg
-    vector3d_t mag; // (x, y, z) arbitrary units, note: need to be converted to uT later
+    vector3d_t mag; // (x, y, z) "arbitrary units" - estimator doesnt need conversion so leave this
     float pres; // Pa
     float temp; // °c
 } movella_data_t;

--- a/tests/unit/imu_handler_test.cpp
+++ b/tests/unit/imu_handler_test.cpp
@@ -3,7 +3,7 @@
  */
 
 #include "fff.h"
-#include "utils/unit_test_helpers.hpp"
+#include "utils/math_testing_helpers.hpp"
 #include <gtest/gtest.h>
 #include <string.h>
 

--- a/tests/unit/imu_handler_test.cpp
+++ b/tests/unit/imu_handler_test.cpp
@@ -57,7 +57,11 @@ static const double INPUT_BARO = 101325.0; // Standard atmospheric pressure in P
 // Expected outputs after orientation correction
 // from matlab commit e20e5d1 (they are all identity matrix rn)
 static const vector3d_t EXPECTED_ACC = {1.0, 2.0, 3.0};
-static const vector3d_t EXPECTED_GYRO = {4.0, 5.0, 6.0};
+static const vector3d_t EXPECTED_GYRO_MOVELLA = {4.0, 5.0, 6.0};
+// expect imu handler converts pololu from deg to rad before orientation correction
+static const vector3d_t EXPECTED_GYRO_POLOLU = {
+    4.0 * M_PI / 180, 5.0 * M_PI / 180, 6.0 * M_PI / 180
+};
 static const vector3d_t EXPECTED_MAG = {7.0, 8.0, 9.0};
 static const vector3d_t EXPECTED_EULER = {10.0, 20.0, 30.0};
 static const double EXPECTED_BARO = 101325.0; // Standard atmospheric pressure in Pa
@@ -182,13 +186,13 @@ TEST_F(ImuHandlerTest, RunSuccessful) {
 
     // Verify data values for Polulu
     assert_vec_eq(EXPECTED_ACC, captured_data.polulu.accelerometer, tolerance);
-    assert_vec_eq(EXPECTED_GYRO, captured_data.polulu.gyroscope, tolerance);
+    assert_vec_eq(EXPECTED_GYRO_POLOLU, captured_data.polulu.gyroscope, tolerance);
     assert_vec_eq(EXPECTED_MAG, captured_data.polulu.magnetometer, tolerance);
     EXPECT_NEAR(captured_data.polulu.barometer, EXPECTED_BARO, abs(EXPECTED_BARO * tolerance));
 
     // Verify Movella data
     assert_vec_eq(EXPECTED_ACC, captured_data.movella.accelerometer, tolerance);
-    assert_vec_eq(EXPECTED_GYRO, captured_data.movella.gyroscope, tolerance);
+    assert_vec_eq(EXPECTED_GYRO_MOVELLA, captured_data.movella.gyroscope, tolerance);
     assert_vec_eq(EXPECTED_MAG, captured_data.movella.magnetometer, tolerance);
     EXPECT_NEAR(captured_data.movella.barometer, EXPECTED_BARO, abs(EXPECTED_BARO * tolerance));
 
@@ -222,7 +226,7 @@ TEST_F(ImuHandlerTest, RunWithPoluluFailure) {
 
     // Verify Movella data is still correct and not dead
     assert_vec_eq(EXPECTED_ACC, captured_data.movella.accelerometer, tolerance);
-    assert_vec_eq(EXPECTED_GYRO, captured_data.movella.gyroscope, tolerance);
+    assert_vec_eq(EXPECTED_GYRO_MOVELLA, captured_data.movella.gyroscope, tolerance);
     assert_vec_eq(EXPECTED_MAG, captured_data.movella.magnetometer, tolerance);
     EXPECT_NEAR(captured_data.movella.barometer, EXPECTED_BARO, abs(EXPECTED_BARO * tolerance));
     EXPECT_FALSE(captured_data.movella.is_dead);
@@ -253,7 +257,7 @@ TEST_F(ImuHandlerTest, RunWithMovellaFailure) {
 
     // Verify Polulu data is still correct and not dead
     assert_vec_eq(EXPECTED_ACC, captured_data.polulu.accelerometer, tolerance);
-    assert_vec_eq(EXPECTED_GYRO, captured_data.polulu.gyroscope, tolerance);
+    assert_vec_eq(EXPECTED_GYRO_POLOLU, captured_data.polulu.gyroscope, tolerance);
     assert_vec_eq(EXPECTED_MAG, captured_data.polulu.magnetometer, tolerance);
     EXPECT_NEAR(captured_data.polulu.barometer, EXPECTED_BARO, abs(EXPECTED_BARO * tolerance));
     EXPECT_FALSE(captured_data.polulu.is_dead);

--- a/tests/unit/utils/math_testing_helpers.hpp
+++ b/tests/unit/utils/math_testing_helpers.hpp
@@ -1,5 +1,5 @@
 /**
- * helpful helper functions to use in unit tests
+ * helpful math-related helper functions to use in unit tests
  */
 #pragma once
 
@@ -13,9 +13,9 @@ extern "C" {
 #include "common/math/math.h"
 }
 
-// Helper function to compare vectors
 /**
- * @brief do EXPECT_NEAR on all 3 components of a vector
+ * @brief Helper function to compare vectors
+ * do EXPECT_NEAR on all 3 components of a vector
  * @param expected expected vector
  * @param actual actual vector
  * @param tolerance % of the expected value to use as the tolerance in EXPECT_NEAR

--- a/tests/unit/utils/mock_helpers.hpp
+++ b/tests/unit/utils/mock_helpers.hpp
@@ -1,0 +1,30 @@
+/**
+ * helpful mocking-related helper functions to use in unit tests
+ */
+#pragma once
+
+#include "fff.h"
+#include <gtest/gtest.h>
+#include <string.h>
+
+extern "C" {
+#include "application/estimator/estimator_types.h"
+#include "common/math/math-algebra3d.h"
+#include "common/math/math.h"
+#include "drivers/timer/timer.h"
+}
+
+// helpers for the timer_get_ms function
+
+// w_status_t timer_get_ms(float *time_ms);
+FAKE_VALUE_FUNC(w_status_t, timer_get_ms, float *);
+
+// static makes this accessible to only the *_test.cpp file that includes this header.
+// test file should modify this variable to set the timer value as needed
+static float mock_timer_ms = 0.0f;
+
+// in test setups, set the custom_fake of timer_get_ms_fake to this func
+inline w_status_t timer_get_ms_custom_fake(float *time_ms) {
+    *time_ms = mock_timer_ms;
+    return timer_get_ms_fake.return_val;
+}


### PR DESCRIPTION
- add freertos taskdelay in sd card functions. this is a hack ngl cuz i think it would get overwritten if regenrtae ioc, but at this point we are not regenerating and the diff would show anyway. This change reduces time spent busy-waiting during sd card accesses. Tested and seems to work as intended - the logger task no longer tasks ridiculous amount of task time, and blinky no longer gets starved during long sd card accesses.
- add more log data + parse script. tested both. fixed imu data logging because struct was not packed
- estimator runs without encoder, though encoder still being logged