### PR TITLE
CAN Fatal Err Implementation

### DIFF
--- a/Core/Src/stm32h7xx_it.c
+++ b/Core/Src/stm32h7xx_it.c
@@ -1,27 +1,28 @@
 /* USER CODE BEGIN Header */
 /**
-  ******************************************************************************
-  * @file    stm32h7xx_it.c
-  * @brief   Interrupt Service Routines.
-  ******************************************************************************
-  * @attention
-  *
-  * Copyright (c) 2024 STMicroelectronics.
-  * All rights reserved.
-  *
-  * This software is licensed under terms that can be found in the LICENSE file
-  * in the root directory of this software component.
-  * If no LICENSE file comes with this software, it is provided AS-IS.
-  *
-  ******************************************************************************
-  */
+ ******************************************************************************
+ * @file    stm32h7xx_it.c
+ * @brief   Interrupt Service Routines.
+ ******************************************************************************
+ * @attention
+ *
+ * Copyright (c) 2024 STMicroelectronics.
+ * All rights reserved.
+ *
+ * This software is licensed under terms that can be found in the LICENSE file
+ * in the root directory of this software component.
+ * If no LICENSE file comes with this software, it is provided AS-IS.
+ *
+ ******************************************************************************
+ */
 /* USER CODE END Header */
 
 /* Includes ------------------------------------------------------------------*/
-#include "main.h"
 #include "stm32h7xx_it.h"
+#include "main.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "application/can_handler/can_handler.h" // Include for fatal error handler
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -74,91 +75,81 @@ extern TIM_HandleTypeDef htim6;
 /*           Cortex Processor Interruption and Exception Handlers          */
 /******************************************************************************/
 /**
-  * @brief This function handles Non maskable interrupt.
-  */
-void NMI_Handler(void)
-{
-  /* USER CODE BEGIN NonMaskableInt_IRQn 0 */
+ * @brief This function handles Non maskable interrupt.
+ */
+void NMI_Handler(void) {
+    /* USER CODE BEGIN NonMaskableInt_IRQn 0 */
 
-  /* USER CODE END NonMaskableInt_IRQn 0 */
-  /* USER CODE BEGIN NonMaskableInt_IRQn 1 */
-  while (1)
-  {
-  }
-  /* USER CODE END NonMaskableInt_IRQn 1 */
+    /* USER CODE END NonMaskableInt_IRQn 0 */
+    /* USER CODE BEGIN NonMaskableInt_IRQn 1 */
+    while (1) {}
+    /* USER CODE END NonMaskableInt_IRQn 1 */
 }
 
 /**
-  * @brief This function handles Hard fault interrupt.
-  */
-void HardFault_Handler(void)
-{
-  /* USER CODE BEGIN HardFault_IRQn 0 */
+ * @brief This function handles Hard fault interrupt.
+ */
+void HardFault_Handler(void) {
+    /* USER CODE BEGIN HardFault_IRQn 0 */
 
-  /* USER CODE END HardFault_IRQn 0 */
-  while (1)
-  {
-    /* USER CODE BEGIN W1_HardFault_IRQn 0 */
-    /* USER CODE END W1_HardFault_IRQn 0 */
-  }
+    /* USER CODE END HardFault_IRQn 0 */
+    while (1) {
+        /* USER CODE BEGIN W1_HardFault_IRQn 0 */
+        // Attempt to send CAN message and enter safe state
+        CanHandler_HandleFatalError("HardFlt"); // Use short error code
+        /* USER CODE END W1_HardFault_IRQn 0 */
+    }
 }
 
 /**
-  * @brief This function handles Memory management fault.
-  */
-void MemManage_Handler(void)
-{
-  /* USER CODE BEGIN MemoryManagement_IRQn 0 */
+ * @brief This function handles Memory management fault.
+ */
+void MemManage_Handler(void) {
+    /* USER CODE BEGIN MemoryManagement_IRQn 0 */
 
-  /* USER CODE END MemoryManagement_IRQn 0 */
-  while (1)
-  {
-    /* USER CODE BEGIN W1_MemoryManagement_IRQn 0 */
-    /* USER CODE END W1_MemoryManagement_IRQn 0 */
-  }
+    /* USER CODE END MemoryManagement_IRQn 0 */
+    while (1) {
+        /* USER CODE BEGIN W1_MemoryManagement_IRQn 0 */
+        /* USER CODE END W1_MemoryManagement_IRQn 0 */
+    }
 }
 
 /**
-  * @brief This function handles Pre-fetch fault, memory access fault.
-  */
-void BusFault_Handler(void)
-{
-  /* USER CODE BEGIN BusFault_IRQn 0 */
+ * @brief This function handles Pre-fetch fault, memory access fault.
+ */
+void BusFault_Handler(void) {
+    /* USER CODE BEGIN BusFault_IRQn 0 */
 
-  /* USER CODE END BusFault_IRQn 0 */
-  while (1)
-  {
-    /* USER CODE BEGIN W1_BusFault_IRQn 0 */
-    /* USER CODE END W1_BusFault_IRQn 0 */
-  }
+    /* USER CODE END BusFault_IRQn 0 */
+    while (1) {
+        /* USER CODE BEGIN W1_BusFault_IRQn 0 */
+        /* USER CODE END W1_BusFault_IRQn 0 */
+    }
 }
 
 /**
-  * @brief This function handles Undefined instruction or illegal state.
-  */
-void UsageFault_Handler(void)
-{
-  /* USER CODE BEGIN UsageFault_IRQn 0 */
+ * @brief This function handles Undefined instruction or illegal state.
+ */
+void UsageFault_Handler(void) {
+    /* USER CODE BEGIN UsageFault_IRQn 0 */
 
-  /* USER CODE END UsageFault_IRQn 0 */
-  while (1)
-  {
-    /* USER CODE BEGIN W1_UsageFault_IRQn 0 */
-    /* USER CODE END W1_UsageFault_IRQn 0 */
-  }
+    /* USER CODE END UsageFault_IRQn 0 */
+    while (1) {
+        /* USER CODE BEGIN W1_UsageFault_IRQn 0 */
+        /* USER CODE END W1_UsageFault_IRQn 0 */
+    }
 }
 
 /**
-  * @brief This function handles Debug monitor.
-  */
-void DebugMon_Handler(void)
-{
-  /* USER CODE BEGIN DebugMonitor_IRQn 0 */
+ * @brief This function handles Debug monitor.
+ */
+void DebugMon_Handler(void) {
+    /* USER CODE BEGIN DebugMonitor_IRQn 0 */
 
-  /* USER CODE END DebugMonitor_IRQn 0 */
-  /* USER CODE BEGIN DebugMonitor_IRQn 1 */
+    /* USER CODE END DebugMonitor_IRQn 0 */
+    /* USER CODE BEGIN DebugMonitor_IRQn 1 */
 
-  /* USER CODE END DebugMonitor_IRQn 1 */
+    /* USER CODE END DebugMonitor_IRQn 1 */
 }
 
 /******************************************************************************/
@@ -169,171 +160,160 @@ void DebugMon_Handler(void)
 /******************************************************************************/
 
 /**
-  * @brief This function handles ADC1 and ADC2 global interrupts.
-  */
-void ADC_IRQHandler(void)
-{
-  /* USER CODE BEGIN ADC_IRQn 0 */
+ * @brief This function handles ADC1 and ADC2 global interrupts.
+ */
+void ADC_IRQHandler(void) {
+    /* USER CODE BEGIN ADC_IRQn 0 */
 
-  /* USER CODE END ADC_IRQn 0 */
-  HAL_ADC_IRQHandler(&hadc1);
-  /* USER CODE BEGIN ADC_IRQn 1 */
+    /* USER CODE END ADC_IRQn 0 */
+    HAL_ADC_IRQHandler(&hadc1);
+    /* USER CODE BEGIN ADC_IRQn 1 */
 
-  /* USER CODE END ADC_IRQn 1 */
+    /* USER CODE END ADC_IRQn 1 */
 }
 
 /**
-  * @brief This function handles FDCAN1 interrupt 0.
-  */
-void FDCAN1_IT0_IRQHandler(void)
-{
-  /* USER CODE BEGIN FDCAN1_IT0_IRQn 0 */
+ * @brief This function handles FDCAN1 interrupt 0.
+ */
+void FDCAN1_IT0_IRQHandler(void) {
+    /* USER CODE BEGIN FDCAN1_IT0_IRQn 0 */
 
-  /* USER CODE END FDCAN1_IT0_IRQn 0 */
-  HAL_FDCAN_IRQHandler(&hfdcan1);
-  /* USER CODE BEGIN FDCAN1_IT0_IRQn 1 */
+    /* USER CODE END FDCAN1_IT0_IRQn 0 */
+    HAL_FDCAN_IRQHandler(&hfdcan1);
+    /* USER CODE BEGIN FDCAN1_IT0_IRQn 1 */
 
-  /* USER CODE END FDCAN1_IT0_IRQn 1 */
+    /* USER CODE END FDCAN1_IT0_IRQn 1 */
 }
 
 /**
-  * @brief This function handles I2C2 event interrupt.
-  */
-void I2C2_EV_IRQHandler(void)
-{
-  /* USER CODE BEGIN I2C2_EV_IRQn 0 */
+ * @brief This function handles I2C2 event interrupt.
+ */
+void I2C2_EV_IRQHandler(void) {
+    /* USER CODE BEGIN I2C2_EV_IRQn 0 */
 
-  /* USER CODE END I2C2_EV_IRQn 0 */
-  HAL_I2C_EV_IRQHandler(&hi2c2);
-  /* USER CODE BEGIN I2C2_EV_IRQn 1 */
+    /* USER CODE END I2C2_EV_IRQn 0 */
+    HAL_I2C_EV_IRQHandler(&hi2c2);
+    /* USER CODE BEGIN I2C2_EV_IRQn 1 */
 
-  /* USER CODE END I2C2_EV_IRQn 1 */
+    /* USER CODE END I2C2_EV_IRQn 1 */
 }
 
 /**
-  * @brief This function handles I2C2 error interrupt.
-  */
-void I2C2_ER_IRQHandler(void)
-{
-  /* USER CODE BEGIN I2C2_ER_IRQn 0 */
+ * @brief This function handles I2C2 error interrupt.
+ */
+void I2C2_ER_IRQHandler(void) {
+    /* USER CODE BEGIN I2C2_ER_IRQn 0 */
 
-  /* USER CODE END I2C2_ER_IRQn 0 */
-  HAL_I2C_ER_IRQHandler(&hi2c2);
-  /* USER CODE BEGIN I2C2_ER_IRQn 1 */
+    /* USER CODE END I2C2_ER_IRQn 0 */
+    HAL_I2C_ER_IRQHandler(&hi2c2);
+    /* USER CODE BEGIN I2C2_ER_IRQn 1 */
 
-  /* USER CODE END I2C2_ER_IRQn 1 */
+    /* USER CODE END I2C2_ER_IRQn 1 */
 }
 
 /**
-  * @brief This function handles SDMMC1 global interrupt.
-  */
-void SDMMC1_IRQHandler(void)
-{
-  /* USER CODE BEGIN SDMMC1_IRQn 0 */
+ * @brief This function handles SDMMC1 global interrupt.
+ */
+void SDMMC1_IRQHandler(void) {
+    /* USER CODE BEGIN SDMMC1_IRQn 0 */
 
-  /* USER CODE END SDMMC1_IRQn 0 */
-  HAL_SD_IRQHandler(&hsd1);
-  /* USER CODE BEGIN SDMMC1_IRQn 1 */
+    /* USER CODE END SDMMC1_IRQn 0 */
+    HAL_SD_IRQHandler(&hsd1);
+    /* USER CODE BEGIN SDMMC1_IRQn 1 */
 
-  /* USER CODE END SDMMC1_IRQn 1 */
+    /* USER CODE END SDMMC1_IRQn 1 */
 }
 
 /**
-  * @brief This function handles UART4 global interrupt.
-  */
-void UART4_IRQHandler(void)
-{
-  /* USER CODE BEGIN UART4_IRQn 0 */
+ * @brief This function handles UART4 global interrupt.
+ */
+void UART4_IRQHandler(void) {
+    /* USER CODE BEGIN UART4_IRQn 0 */
 
-  /* USER CODE END UART4_IRQn 0 */
-  HAL_UART_IRQHandler(&huart4);
-  /* USER CODE BEGIN UART4_IRQn 1 */
+    /* USER CODE END UART4_IRQn 0 */
+    HAL_UART_IRQHandler(&huart4);
+    /* USER CODE BEGIN UART4_IRQn 1 */
 
-  /* USER CODE END UART4_IRQn 1 */
+    /* USER CODE END UART4_IRQn 1 */
 }
 
 /**
-  * @brief This function handles TIM6 global interrupt, DAC1_CH1 and DAC1_CH2 underrun error interrupts.
-  */
-void TIM6_DAC_IRQHandler(void)
-{
-  /* USER CODE BEGIN TIM6_DAC_IRQn 0 */
+ * @brief This function handles TIM6 global interrupt, DAC1_CH1 and DAC1_CH2 underrun error
+ * interrupts.
+ */
+void TIM6_DAC_IRQHandler(void) {
+    /* USER CODE BEGIN TIM6_DAC_IRQn 0 */
 
-  /* USER CODE END TIM6_DAC_IRQn 0 */
-  HAL_TIM_IRQHandler(&htim6);
-  /* USER CODE BEGIN TIM6_DAC_IRQn 1 */
-  ulHighFrequencyTimerTicks++; // TODO: FOR DEVELOPMENT
-  /* USER CODE END TIM6_DAC_IRQn 1 */
+    /* USER CODE END TIM6_DAC_IRQn 0 */
+    HAL_TIM_IRQHandler(&htim6);
+    /* USER CODE BEGIN TIM6_DAC_IRQn 1 */
+    ulHighFrequencyTimerTicks++; // TODO: FOR DEVELOPMENT
+    /* USER CODE END TIM6_DAC_IRQn 1 */
 }
 
 /**
-  * @brief This function handles UART8 global interrupt.
-  */
-void UART8_IRQHandler(void)
-{
-  /* USER CODE BEGIN UART8_IRQn 0 */
+ * @brief This function handles UART8 global interrupt.
+ */
+void UART8_IRQHandler(void) {
+    /* USER CODE BEGIN UART8_IRQn 0 */
 
-  /* USER CODE END UART8_IRQn 0 */
-  HAL_UART_IRQHandler(&huart8);
-  /* USER CODE BEGIN UART8_IRQn 1 */
+    /* USER CODE END UART8_IRQn 0 */
+    HAL_UART_IRQHandler(&huart8);
+    /* USER CODE BEGIN UART8_IRQn 1 */
 
-  /* USER CODE END UART8_IRQn 1 */
+    /* USER CODE END UART8_IRQn 1 */
 }
 
 /**
-  * @brief This function handles I2C4 event interrupt.
-  */
-void I2C4_EV_IRQHandler(void)
-{
-  /* USER CODE BEGIN I2C4_EV_IRQn 0 */
+ * @brief This function handles I2C4 event interrupt.
+ */
+void I2C4_EV_IRQHandler(void) {
+    /* USER CODE BEGIN I2C4_EV_IRQn 0 */
 
-  /* USER CODE END I2C4_EV_IRQn 0 */
-  HAL_I2C_EV_IRQHandler(&hi2c4);
-  /* USER CODE BEGIN I2C4_EV_IRQn 1 */
+    /* USER CODE END I2C4_EV_IRQn 0 */
+    HAL_I2C_EV_IRQHandler(&hi2c4);
+    /* USER CODE BEGIN I2C4_EV_IRQn 1 */
 
-  /* USER CODE END I2C4_EV_IRQn 1 */
+    /* USER CODE END I2C4_EV_IRQn 1 */
 }
 
 /**
-  * @brief This function handles I2C4 error interrupt.
-  */
-void I2C4_ER_IRQHandler(void)
-{
-  /* USER CODE BEGIN I2C4_ER_IRQn 0 */
+ * @brief This function handles I2C4 error interrupt.
+ */
+void I2C4_ER_IRQHandler(void) {
+    /* USER CODE BEGIN I2C4_ER_IRQn 0 */
 
-  /* USER CODE END I2C4_ER_IRQn 0 */
-  HAL_I2C_ER_IRQHandler(&hi2c4);
-  /* USER CODE BEGIN I2C4_ER_IRQn 1 */
+    /* USER CODE END I2C4_ER_IRQn 0 */
+    HAL_I2C_ER_IRQHandler(&hi2c4);
+    /* USER CODE BEGIN I2C4_ER_IRQn 1 */
 
-  /* USER CODE END I2C4_ER_IRQn 1 */
+    /* USER CODE END I2C4_ER_IRQn 1 */
 }
 
 /**
-  * @brief This function handles FMAC interrupt.
-  */
-void FMAC_IRQHandler(void)
-{
-  /* USER CODE BEGIN FMAC_IRQn 0 */
+ * @brief This function handles FMAC interrupt.
+ */
+void FMAC_IRQHandler(void) {
+    /* USER CODE BEGIN FMAC_IRQn 0 */
 
-  /* USER CODE END FMAC_IRQn 0 */
-  HAL_FMAC_IRQHandler(&hfmac);
-  /* USER CODE BEGIN FMAC_IRQn 1 */
+    /* USER CODE END FMAC_IRQn 0 */
+    HAL_FMAC_IRQHandler(&hfmac);
+    /* USER CODE BEGIN FMAC_IRQn 1 */
 
-  /* USER CODE END FMAC_IRQn 1 */
+    /* USER CODE END FMAC_IRQn 1 */
 }
 
 /**
-  * @brief This function handles CORDIC interrupt.
-  */
-void CORDIC_IRQHandler(void)
-{
-  /* USER CODE BEGIN CORDIC_IRQn 0 */
+ * @brief This function handles CORDIC interrupt.
+ */
+void CORDIC_IRQHandler(void) {
+    /* USER CODE BEGIN CORDIC_IRQn 0 */
 
-  /* USER CODE END CORDIC_IRQn 0 */
-  HAL_CORDIC_IRQHandler(&hcordic);
-  /* USER CODE BEGIN CORDIC_IRQn 1 */
+    /* USER CODE END CORDIC_IRQn 0 */
+    HAL_CORDIC_IRQHandler(&hcordic);
+    /* USER CODE BEGIN CORDIC_IRQn 1 */
 
-  /* USER CODE END CORDIC_IRQn 1 */
+    /* USER CODE END CORDIC_IRQn 1 */
 }
 
 /* USER CODE BEGIN 1 */

--- a/src/application/can_handler/can_handler.c
+++ b/src/application/can_handler/can_handler.c
@@ -190,7 +190,7 @@ void CanHandler_HandleFatalError(const char *errorMsg) {
         strncpy((char *)&msg.data[2], errorMsg, sizeof(msg.data) - 2);
         msg.data[sizeof(msg.data) - 1] = '\0'; // Ensure null termination
     } // else: payload[2-7] remain 0
-    msg.data_len = CAN_MAX_DLC; // Use max DLC (8 bytes)
+    msg.data_len = 8; // Use max DLC (8 bytes)
 
     // --- Identifier (SID) ---
     // Manually construct the 29-bit identifier according to RocketCAN 2.0B spec

--- a/src/application/can_handler/can_handler.c
+++ b/src/application/can_handler/can_handler.c
@@ -8,6 +8,15 @@
 #include "drivers/gpio/gpio.h"
 #include "drivers/timer/timer.h"
 
+// headers for fatal error handler
+#include "stm32h7xx_hal.h" // For __disable_irq, __NOP
+#include "third_party/canlib/can.h" // Main canlib header
+#include "third_party/canlib/can_ids.h" // For CAN ID defines
+#include "third_party/canlib/can_msg_defs.h" // For message type defines
+#include "third_party/canlib/message_types.h" // For Board/Msg IDs
+#include <stdint.h>
+#include <string.h>
+
 // TODO: calculate better. for now make excessively large and check dropped tx counter
 #define BUS_QUEUE_LENGTH 32
 
@@ -163,3 +172,59 @@ void can_handler_task_tx(void *argument) {
         }
     }
 }
+
+// --- Fatal Error Handler Implementation ---
+
+// Note: All IDs (Board Type, Message Type, Instance ID)
+//       are used directly from canlib/message_types.h
+
+void CanHandler_HandleFatalError(const char *errorMsg) {
+    can_msg_t msg;
+    memset(&msg, 0, sizeof(msg)); // Zero out the message struct initially
+
+    // --- Payload ---
+    // Set timestamp bytes to 0 - unreliable to get timestamp in fault state
+    msg.data[0] = 0;
+    msg.data[1] = 0;
+    // Copy error message (max 6 bytes)
+    // Ensure errorMsg is not NULL before copying
+    if (errorMsg != NULL) {
+        strncpy((char *)&msg.data[2], errorMsg, sizeof(msg.data) - 2);
+        msg.data[sizeof(msg.data) - 1] = '\0'; // Ensure null termination
+    } // else: payload[2-7] remain 0
+    msg.data_len = CAN_MAX_DLC; // Use max DLC (8 bytes)
+
+    // --- Identifier (SID) ---
+    // Manually construct the 29-bit identifier according to RocketCAN 2.0B spec
+    // Priority (Bits 28:27) = 0b01 (High)
+    // Message Type (Bits 26:18) = MSG_DEBUG_RAW
+    // Reserved (Bits 17:16) = 0b00 (Implicitly zero)
+    // Board Type ID (Bits 15:8) = BOARD_TYPE_ID_PROCESSOR
+    // Board Instance ID (Bits 7:0) = BOARD_INST_ID_GENERIC (0x01)
+
+    msg.sid = ((uint32_t)0b01 << 27) | // Priority (High)
+              ((uint32_t)MSG_DEBUG_RAW << 18) | // Message Type
+              ((uint32_t)BOARD_TYPE_ID_PROCESSOR << 8) | // Board Type ID
+              ((uint32_t)BOARD_INST_ID_GENERIC << 0); // Board Instance ID
+
+    // Note: can_send implicitly handles extended ID based on platform config (STM32H7).
+
+    // 2. Attempt to transmit the message using canlib's low-level send
+    // This bypasses the FreeRTOS queue used by can_handler_transmit
+    can_send(&msg);
+
+    // No delay here - can_send should handle necessary waits.
+
+    // 3. Enter Safe State
+    // Disable interrupts - prevents further execution
+    __disable_irq();
+
+    // Infinite loop - System HALT
+    while (1) {
+        // Prevent optimization and provide breakpoint target
+        __NOP();
+    }
+}
+
+// --- End Fatal Error Handler ---
+

--- a/src/application/can_handler/can_handler.c
+++ b/src/application/can_handler/can_handler.c
@@ -8,11 +8,9 @@
 #include "drivers/gpio/gpio.h"
 #include "drivers/timer/timer.h"
 
-// headers for fatal error handler
+// Include necessary headers for fatal error handler
 #include "stm32h7xx_hal.h" // For __disable_irq, __NOP
-#include "third_party/canlib/can.h" // Main canlib header
-#include "third_party/canlib/can_ids.h" // For CAN ID defines
-#include "third_party/canlib/can_msg_defs.h" // For message type defines
+#include "third_party/canlib/can.h" // For can_msg_t, can_send
 #include "third_party/canlib/message_types.h" // For Board/Msg IDs
 #include <stdint.h>
 #include <string.h>

--- a/src/application/can_handler/can_handler.h
+++ b/src/application/can_handler/can_handler.h
@@ -44,4 +44,26 @@ void can_handler_task_rx(void *argument);
  * @brief When busqueue_tx recieves a message, this task sends it to the can bus
  */
 void can_handler_task_tx(void *argument);
+
+/**
+ * @brief Get the status of the CAN handler
+ * @return Status of the operation
+ */
+w_status_t can_handler_get_status(void);
+
+/**
+ * @brief Handles a fatal system error by sending a CAN message.
+ *
+ * This function attempts to send a CAN message indicating the error and then
+ * enters a safe, non-recoverable state (infinite loop with interrupts disabled).
+ * It is designed to be called in critical failure scenarios where normal error
+ * logging (e.g., to SD card) or task execution may not be possible.
+ *
+ * It uses the canlib library to send a DEBUG_RAW message with a coarse timestamp
+ * and the first few characters of the error message.
+ *
+ * @param errorMsg A descriptive string for the error (only the first ~6 chars will be sent).
+ */
+void CanHandler_HandleFatalError(const char *errorMsg);
+
 #endif

--- a/src/application/estimator/model/model_dynamics.c
+++ b/src/application/estimator/model/model_dynamics.c
@@ -133,11 +133,10 @@ void model_dynamics_jacobian(
     aerodynamics_jacobian(state, &airdata, &torque_v, &torque_cl, &torque_delta);
     // **tilde start
     const matrix3d_t w_tilde = {
-        .array = {
-            {0, state->rates.z, -state->rates.y},
-            {-state->rates.z, 0, state->rates.x},
-            {state->rates.y, -state->rates.x, 0}
-        }
+        .array =
+            {{0, state->rates.z, -state->rates.y},
+             {-state->rates.z, 0, state->rates.x},
+             {state->rates.y, -state->rates.x, 0}}
     }; // -tilde(w)
     // **tilde end
     const matrix3d_t J_w_tilde = math_matrix3d_mult(&J, &w_tilde); // -param.J * tilde(w)
@@ -182,18 +181,20 @@ void model_dynamics_jacobian(
     const vector3d_t v_scaled = math_vector3d_scale(-dt, &state->velocity);
     // **tilde start
     const matrix3d_t v_w = {
-        .array = {
-            {0, -v_scaled.z, v_scaled.y}, {v_scaled.z, 0, -v_scaled.x}, {-v_scaled.y, v_scaled.x, 0}
-        }
+        .array =
+            {{0, -v_scaled.z, v_scaled.y},
+             {v_scaled.z, 0, -v_scaled.x},
+             {-v_scaled.y, v_scaled.x, 0}}
     }; // - dt * tilde(v)
     // **tilde end
 
     const vector3d_t w_scaled = math_vector3d_scale(dt, &state->rates);
     // **tilde start
     const matrix3d_t w_scaled_tilde = {
-        .array = {
-            {0, -w_scaled.z, w_scaled.y}, {w_scaled.z, 0, -w_scaled.x}, {-w_scaled.y, w_scaled.x, 0}
-        }
+        .array =
+            {{0, -w_scaled.z, w_scaled.y},
+             {w_scaled.z, 0, -w_scaled.x},
+             {-w_scaled.y, w_scaled.x, 0}}
     }; // dt * tilde(w)
     // **tilde end
     const matrix3d_t v_v = math_matrix3d_add(&idn, &w_scaled_tilde); // eye(3) + dt * tilde(v)


### PR DESCRIPTION
- Introduced CanHandler_HandleFatalError function in can_handler.h to manage fatal system errors via CAN messaging.