### PR TITLE
Increase Movella Data Rates to 200Hz

### DIFF
--- a/src/drivers/movella/movella.c
+++ b/src/drivers/movella/movella.c
@@ -10,7 +10,6 @@
 #include "drivers/movella/movella.h"
 #include "drivers/uart/uart.h"
 
-#define MOVELLA_OUTPUT_RATE 100
 #define UART_TX_TIMEOUT_MS 100
 #define UART_RX_TIMEOUT_MS 20
 #define XSENS_ARR_ELEM 7
@@ -127,12 +126,12 @@ w_status_t movella_get_data(movella_data_t *out_data, uint32_t timeout_ms) {
 
 static void movella_configure(void) {
     XsensFrequencyConfig_t settings[XSENS_ARR_ELEM] = {
-        {.id = XDI_QUATERNION, .frequency = 100},
-        {.id = XDI_ACCELERATION, .frequency = 100},
-        {.id = XDI_RATE_OF_TURN, .frequency = 100},
-        {.id = XDI_MAGNETIC_FIELD, .frequency = 50},
-        {.id = XDI_TEMPERATURE, .frequency = 5},
-        {.id = XDI_BARO_PRESSURE, .frequency = 5},
+        {.id = XDI_QUATERNION, .frequency = 200}, // 5ms
+        {.id = XDI_ACCELERATION, .frequency = 200}, // 5ms
+        {.id = XDI_RATE_OF_TURN, .frequency = 200}, // 5ms
+        {.id = XDI_MAGNETIC_FIELD, .frequency = 100}, // 10ms
+        {.id = XDI_TEMPERATURE, .frequency = 5}, // 200ms
+        {.id = XDI_BARO_PRESSURE, .frequency = 40}, // 25ms
         {.id = XDI_STATUS_WORD, .frequency = 0xFFFF}
     };
 


### PR DESCRIPTION
Increase the frequency of Movella data to up to 200Hz.

Quaternion rates: 100Hz -> 200Hz
Acceleration rates: 100Hz -> 200Hz
Rate of turn rates: 100Hz -> 200Hz
Magnetic field rates: 50Hz -> 100Hz
Temperature rates: 5Hz
barometer rates: 5hz -> 40Hz

Design document: https://docs.google.com/document/d/1OokvdQ8c74xzt_znfmBUrUzJ5vtqvndMz0l9xxN98dY/edit?tab=t.0#heading=h.rnvybb1qjnlc
