### PR TITLE
Bugfix2

### DIFF
--- a/src/application/controller/controller.c
+++ b/src/application/controller/controller.c
@@ -11,7 +11,7 @@
 static QueueHandle_t internal_state_queue;
 static QueueHandle_t output_queue;
 
-#define CONTROLLER_CYCLE_MS 5
+#define CONTROLLER_CYCLE_MS 10
 #define ERROR_TIMEOUT_MS 10
 #define RECOVERY_TIMEOUT_MS 1000
 #define STATE_ELSE_TIMEOUT_MS 1
@@ -192,8 +192,7 @@ w_status_t controller_run_loop() {
                 // if anything fails, send no cmd. MCB failsafes to 0 after 100ms of silence
                 log_text(ERROR_TIMEOUT_MS, "controller", "fail; send no cmd");
             } else {
-                // ref_signal ignored here, so just set to 0
-                status |= process_new_cmd(new_cmd, 0);
+                status |= process_new_cmd(new_cmd, ref_signal);
             }
 
             break;

--- a/src/application/estimator/estimator.c
+++ b/src/application/estimator/estimator.c
@@ -99,7 +99,7 @@ w_status_t estimator_run_loop(estimator_module_ctx_t *ctx, uint32_t loop_count) 
     bool encoder_is_dead = false;
 
     // get latest imu data, transform into estimator data structs.
-    if (xQueueReceive(imu_data_queue, &latest_imu_data, 5) != pdTRUE) {
+    if (xQueueReceive(imu_data_queue, &latest_imu_data, 10) != pdTRUE) {
         log_text(5, "estimator", "imu data q empty");
         return W_FAILURE;
     }

--- a/src/application/init/init.c
+++ b/src/application/init/init.c
@@ -17,9 +17,11 @@
 #include "drivers/uart/uart.h"
 #include "stm32h7xx_hal.h"
 // Add these includes for hardware handles
+#include "FreeRTOS.h"
 #include "adc.h" // For hadc1
 #include "fdcan.h" // For hfdcan1
 #include "i2c.h" // For hi2c2, hi2c4
+#include "task.h"
 #include "usart.h" // For huart4, huart8
 
 // Initialize task handles to NULL
@@ -93,6 +95,10 @@ w_status_t init_with_retry_param(w_status_t (*init_fn)(void *), void *param) {
 
 // Main initialization function
 w_status_t system_init(void) {
+    // hotfix: allow time for .... stuff ?? ... before init.
+    // without this, the uart DMA change made proc freeze upon power cycle
+    vTaskDelay(500);
+
     w_status_t status = W_SUCCESS;
 
     // Initialize hardware peripherals


### PR DESCRIPTION
skill issues

sample log using Release build and hardcoding controller input dyn_p to 20000:

```[78059.1] canard_cmd (type 2) with
    cmd_angle: 0.09960076212882996
    ref_signal: 0.5
[78059.2] controller_input (type 3) with
    roll_angle: 0.06566499918699265
    roll_rate: -0.16824935376644135
    canard_angle: 0.0
    p_dyn: 0.06356144696474075
    canard_coeff: 3.4926841259002686
[78059.2] ekf_ctx_pt1 (type 19) with
    attitude_w: 0.9993786811828613
    attitude_x: 0.032889820635318756
    attitude_y: 0.011028877459466457
    attitude_z: -0.006233398336917162
    altitude: 249.18463134765625
[78059.2] ekf_ctx_pt2 (type 20) with
    rates_x: -0.16824935376644135
    rates_y: -0.001680625369772315
    rates_z: -0.0068525103852152824
    CL: 3.4926841259002686
    delta: -0.013264717534184456
[78059.2] ekf_ctx_pt3 (type 21) with
    velocity_x: -0.1342514157295227
    velocity_y: -0.28550776839256287
    velocity_z: -0.08220867812633514
    t: 78.05630493164062
[78061.7] movella_pt1 (type 16) with
    movella_acc_x: 9.771808624267578
    movella_acc_y: -0.20768709480762482
    movella_acc_z: 0.20804914832115173
[78061.7] movella_pt2 (type 17) with
    movella_gyr_x: -0.21906794607639313
    movella_gyr_y: 0.0009663404780440032
    movella_gyr_z: -0.018298625946044922
[78061.7] movella_pt3 (type 18) with
    movella_mag_x: -0.8738181591033936
    movella_mag_y: -0.007494926452636719
    movella_mag_z: -0.3923940658569336
    movella_bar: 98248.0
    movella_time: 78060
    movella_is_dead: False
[78061.7] pololu_pt1 (type 22) with
    pololu_acc_x: 9.494147300720215
    pololu_acc_y: 0.8622333407402039
    pololu_acc_z: 0.13891537487506866
[78061.8] pololu_pt2 (type 23) with
    pololu_gyr_x: -0.24501830339431763
    pololu_gyr_y: -0.013848860748112202
    pololu_gyr_z: -0.011718266643583775
[78061.8] pololu_pt3 (type 24) with
    pololu_mag_x: -0.143559068441391
    pololu_mag_y: -0.08398693799972534
    pololu_mag_z: -0.4194464087486267
    pololu_bar: 98584.7890625
    pololu_time: 78060
    pololu_is_dead: False
[78061.8] raw_pololu_pt1 (type 25) with
    acc_x: -180
    acc_y: 29
    acc_z: -1982
    gyro_x: 13
    gyro_y: -11
    gyro_z: 230
[78061.8] raw_pololu_pt2 (type 26) with
    mag_x: 172
    mag_y: -859
    mag_z: 294
    baro_pres: 4038033
    baro_temp: 2503
[78062.7] encoder (type 6) with
    encoder_value: -0.017261305823922157
[78064.2] canard_cmd (type 2) with
    cmd_angle: 0.10276782512664795
    ref_signal: 0.5
[78064.2] controller_input (type 3) with
    roll_angle: 0.06473720073699951
    roll_rate: -0.22867335379123688
    canard_angle: 0.0
    p_dyn: 0.0633457601070404
    canard_coeff: 3.4940738677978516
[78064.2] ekf_ctx_pt1 (type 19) with
    attitude_w: 0.9993937611579895```