### PR TITLE
add float32_t and float64_t types

### DIFF
--- a/src/application/estimator/estimator.h
+++ b/src/application/estimator/estimator.h
@@ -14,7 +14,7 @@ typedef struct {
 	vector3d_t accelerometer; // gravities
 	vector3d_t gyroscope; // rad/sec
 	vector3d_t magnetometer; // mgauss (pololu) or arbitrary units (movella)
-	float barometer; // Pa
+	float32_t barometer; // Pa
 	bool is_dead;
 } estimator_imu_measurement_t;
 

--- a/src/common/math/math.h
+++ b/src/common/math/math.h
@@ -13,6 +13,20 @@
 #define M_PI 3.14159265
 #endif
 
+// these typedefs work for stm32 arm toolchain because float is 32-bit and double is 64-bit.
+// asserts below verify that for good measure.
+typedef float float32_t;
+typedef double float64_t;
+
+#if defined(__cplusplus)
+#define STATIC_ASSERT static_assert
+#else
+#define STATIC_ASSERT _Static_assert
+#endif
+
+STATIC_ASSERT(sizeof(float32_t) == 4, "float32_t must be 32 bits");
+STATIC_ASSERT(sizeof(float64_t) == 8, "float64_t must be 64 bits");
+
 static inline bool float_equal(double a, double b) {
 	return fabs(a - b) < 0.00001;
 }


### PR DESCRIPTION
barr 
<img width="1841" height="231" alt="image" src="https://github.com/user-attachments/assets/f017711a-1dec-4b9e-b804-dd91f5615899" />


its fine that our previous code doesn't use this, but moving forward we will use these names