### PR TITLE
fix: fixed casting issues for controller unit test 

### DIFF
--- a/tests/unit/controller_test.cpp
+++ b/tests/unit/controller_test.cpp
@@ -54,7 +54,8 @@ BaseType_t xQueueReceive_custom(QueueHandle_t arg0, void *arg1, TickType_t arg2)
 
 uint16_t rad_to_can_cmd(float rad) {
     // Convert radians to millidegrees and shift to unsigned 16-bit
-    return (uint16_t)(rad / M_PI * 180.0 * 1000.0) + 32768;
+    int16_t res_int16 = (int16_t)(rad / M_PI * 180.0 * 1000.0) + 32768;
+    return (uint16_t)(res_int16); 
 }
 
 class ControllerTest : public ::testing::Test {


### PR DESCRIPTION
float was directly casted to uint16, indeterminant behavior from improper casting 
added int16 as intermediate type 