### PR TITLE
Initialize Timer Module First and Remove Fatal Error Handler Reliance on CAN Handler Init

### DIFF
--- a/src/application/can_handler/can_handler.c
+++ b/src/application/can_handler/can_handler.c
@@ -1,6 +1,7 @@
 #include "FreeRTOS.h"
 #include "application/logger/log.h"
 #include "drivers/gpio/gpio.h"
+#include "fdcan.h" // For hfdcan1 for fatal error handler
 #include "queue.h"
 
 #include "application/can_handler/can_handler.h"
@@ -180,8 +181,14 @@ void can_handler_task_tx(void *argument) {
 //       are used directly from canlib/message_types.h
 
 void proc_handle_fatal_error(const char *errorMsg) {
+	static bool can_initialized = false;
 	// safe state - loop here forever and send CAN err msg repeatedly
 	while (1) {
+		can_initialized =
+			can_initialized ||
+			can_init_stm(&hfdcan1,
+						 can_handle_rx_isr); // BEWARE: this is hardcoded to use hfdcan1, remember
+											 // to change this when our CAN handle changes
 		__disable_irq();
 
 		// let CAN still work
@@ -200,7 +207,7 @@ void proc_handle_fatal_error(const char *errorMsg) {
 		// Use canlib's helper function to build the debug message
 		// Set priority to high and timestamp to 0 (since we can't reliably get timestamp in error
 		// state)
-		if (build_debug_raw_msg(PRIO_HIGH, 0, data, &msg)) {
+		if (build_debug_raw_msg(PRIO_HIGH, 0, data, &msg) && can_initialized) {
 			// Only try to send if message build succeeded
 			can_send(&msg);
 		}

--- a/src/application/init/init.c
+++ b/src/application/init/init.c
@@ -100,6 +100,10 @@ static w_status_t init_with_retry_param(w_status_t (*init_fn)(void *), void *par
 }
 
 static void system_init_task(void *arg) {
+	// initialize timer first to make sure other modules can use it
+	if (W_SUCCESS != timer_init()) {
+		proc_handle_fatal_error("timerinit");
+	}
 	// hotfix: allow time for .... stuff ?? ... before init.
 	// without this, the uart DMA change made proc freeze upon power cycle.
 	// probably because movella triggers before its ready
@@ -116,7 +120,6 @@ static void system_init_task(void *arg) {
 	w_status_t status = W_SUCCESS;
 
 	// INIT REQUIRED MODULES
-	status |= timer_init();
 	status |= gpio_init();
 	status |= i2c_init(I2C_BUS_2, &hi2c2, 0);
 	status |= i2c_init(I2C_BUS_4, &hi2c4, 0);

--- a/src/application/init/init.c
+++ b/src/application/init/init.c
@@ -100,14 +100,15 @@ static w_status_t init_with_retry_param(w_status_t (*init_fn)(void *), void *par
 }
 
 static void system_init_task(void *arg) {
-	// initialize timer first to make sure other modules can use it
-	if (W_SUCCESS != timer_init()) {
-		proc_handle_fatal_error("timerinit");
-	}
 	// hotfix: allow time for .... stuff ?? ... before init.
 	// without this, the uart DMA change made proc freeze upon power cycle.
 	// probably because movella triggers before its ready
 	vTaskDelay(500);
+
+	// initialize timer first to make sure other modules can use it
+	if (W_SUCCESS != timer_init()) {
+		proc_handle_fatal_error("timerinit");
+	}
 
 	// INIT NON-CRITICAL MODULES; try to do logger first
 	w_status_t non_crit_status = sd_card_init();

--- a/src/drivers/timer/timer.c
+++ b/src/drivers/timer/timer.c
@@ -25,7 +25,6 @@ static bool g_timer_initialized = false;
 w_status_t timer_init() {
 	g_timer_initialized = false;
 	if (HAL_OK != HAL_TIM_Base_Start(&htim2)) {
-		log_text(0, "timer", "ERROR: Failed to start TIM CHANNEL 2.");
 		return W_FAILURE;
 	}
 	g_timer_initialized = true;


### PR DESCRIPTION
This is so that other modules can use timer in init.c